### PR TITLE
two fixes to make it production-ready:

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "vite": "^2.5.1",
     "vue-cli-plugin-vuetify": "~2.4.2",
     "vue-tsc": "^0.2.2"
+  },
+  "engines": {
+    "node": "14.x"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     vue(),
     vueI18n({
       include: resolve(__dirname, "./locales/**"),
+      runtimeOnly: false
     }),
   ],
   define: { "process.env": {} },


### PR DESCRIPTION
 - node engine is specified as 14.x - some cloud providers rely on this info and some of the dependencies require at least NodeJS 14
 - Vue18n in production requires to set runtimeonly to false - https://github.com/intlify/vite-plugin-vue-i18n